### PR TITLE
Update hnf in XXX-reduction.md

### DIFF
--- a/text/XXX-reduction.md
+++ b/text/XXX-reduction.md
@@ -7,7 +7,7 @@
 | vm_compute    | ✅✅✅         | Full          | ❌                         | ❌                       | ❌                | ✅✅✅ Bespoke Cast honored by Qed                                                        |
 | lazy          | ✅✅           | Full / Head   | ❌                         | ✅✅                     | ❌                | ✅✅ Default cast does not store reduction flags                                          |
 | cbv,compute   | ✅             | Full / Head   | ❌                         | ❌                       | ❌                | ✅ Default cast coincides but will use kernel reduction/conversion instead of cbv         |
-| hnf           | ❔             | Head          |  ❔                        |  ❔                      |  ❔               |  ❔                                                                                       |
+| hnf           | ❔             | Head          |  ❔                        |  ❌                      | ✅                |  ❔                                                                                       |
 | simpl         | ⛔⛔           | Full / Head   | ✅/⛔                      | ⛔ (only head)           | ✅                | ⛔ Uses default cast                                                                      |
 | cbn           | ⛔⛔⛔         | Full / Head   | ✅✅                       | ✅✅                     | ✅✅              | ⛔ Uses default cast                                                                      |
 | **Proposals** |


### PR DESCRIPTION
Last I checked, hnf uses the reduction strategy and refolding engine of `simpl`.  https://github.com/coq/coq/blob/c9f120d29d3f4c8a6a1cf53a734eb2bc7186cac0/doc/tools/docgram/fullGrammar#L800 indicates that it does not support flags.

Also, you may want to add native_compute